### PR TITLE
8. GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -197,8 +197,8 @@ describe("4. 06-PATCH /api/articles/:article_id", () => {
   });
 });
 
-describe("5. 07-GET /api/articles/:article_id", () => {
-  test("status:200, responds with an article object by it's id with comment_count colum", () => {
+describe("5. 07-GET_comment_count /api/articles/:article_id", () => {
+  test("status:200, responds with an article object by it's id with comment_count column", () => {
     const ARTICLE_ID = 1;
     return request(app)
       .get(`/api/articles/${ARTICLE_ID}`)
@@ -216,6 +216,70 @@ describe("5. 07-GET /api/articles/:article_id", () => {
             comment_count: "11",
           })
         );
+      });
+  });
+});
+
+describe("6. 08-GET_articles /api/articles", () => {
+  test("status:200, responds with an array of test articles objects", () => {
+    return request(app)
+      .get(`/api/articles`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articlesList).toBeInstanceOf(Array);
+        expect(body.articlesList).toHaveLength(12);
+        body.articlesList.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              article_id: expect.any(Number),
+              title: expect.any(String),
+              topic: expect.any(String),
+              author: expect.any(String),
+              body: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              comment_count: expect.any(String),
+            })
+          );
+        });
+      });
+  });
+  test("status:200, responds with an array of test articles objects filtered by 'cats' topic", () => {
+    return request(app)
+      .get(`/api/articles?topic=cats`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articlesList).toBeInstanceOf(Array);
+        body.articlesList.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              topic: "cats",
+            })
+          );
+        });
+      });
+  });
+  test("status:200, responds with an array of test articles objects filtered by 'mitch' topics", () => {
+    return request(app)
+      .get(`/api/articles?topic=mitch`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articlesList).toBeInstanceOf(Array);
+        body.articlesList.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              topic: "mitch",
+            })
+          );
+        });
+      });
+  });
+  test("status:400, responds with an error message when filtered by invalit topic", () => {
+    return request(app)
+      .get(`/api/articles?topic=pizza`)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Invalid topic value");
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const app = express();
 
 const { getTopics } = require("./controllers/topics_controllers");
 const {
+  getArticles,
   getArticleById,
   patchArticleById,
 } = require("./controllers/articles_controllers");
@@ -18,6 +19,7 @@ app.use(express.json());
 
 app.get("/api/topics", getTopics);
 
+app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id", getArticleById);
 app.patch("/api/articles/:article_id", patchArticleById);
 

--- a/controllers/articles_controllers.js
+++ b/controllers/articles_controllers.js
@@ -1,8 +1,20 @@
 const db = require("../db/connection");
 const {
+  selectArticles,
   selectArticleById,
   updateArticleById,
 } = require("../models/articles_models");
+
+exports.getArticles = (req, res, next) => {
+  const {
+    query: { topic },
+  } = req;
+  selectArticles(topic)
+    .then((articlesList) => {
+      res.status(200).send({ articlesList });
+    })
+    .catch(next);
+};
 
 exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;

--- a/models/articles_models.js
+++ b/models/articles_models.js
@@ -1,5 +1,32 @@
 const db = require("../db/connection");
 
+exports.selectArticles = (topic) => {
+  const validTopicValues = ["mitch", "cats", undefined];
+  if (!validTopicValues.includes(topic)) {
+    return Promise.reject({ status: 400, msg: "Invalid topic value" });
+  }
+
+  let baseSQLStart = `SELECT articles.*, COUNT(articles.article_id) AS comment_count
+FROM articles
+LEFT JOIN comments ON comments.article_id = articles.article_id
+`;
+
+  let baseSQLMiddle = ` `;
+  if (topic !== undefined) {
+    baseSQLMiddle += `WHERE topic = '${topic}'`;
+  }
+
+  let baseSQLEnd = `GROUP BY articles.article_id
+  ORDER BY created_at DESC;`;
+
+  let fullSQL = baseSQLStart + baseSQLMiddle + baseSQLEnd;
+
+  return db.query(fullSQL).then((result) => {
+    const articles = result.rows;
+    return articles;
+  });
+};
+
 exports.selectArticleById = (id) => {
   return db
     .query(


### PR DESCRIPTION
- Add "get/api/articles" endpoint and queries for its topic column
- Articles sorted by date in descending order
-The end point also accept the query: `topic`, which filters the articles by the topic value specified in the query. If the query is omitted the endpoint should respond with all articles. 
- add TDD for it